### PR TITLE
Update workflows for .NET 9 and PowerShell v1.0.10

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Setup PowerShell
-      uses: CRFricke/Setup-PowerShell@v1.0.9
+      uses: CRFricke/Setup-PowerShell@v1.0.10
 
     - name: Checkout
       uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
       shell: pwsh
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_PREFIX: 'v8'
+          TAG_PREFIX: 'v9'
       run: |
         Get-VersionVariables
         Set-ActionVariable "BUILD_VERSION" "$Tag_Version"
@@ -33,7 +33,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
         source-url: https://nuget.pkg.github.com/CRFricke/index.json
         owner: CRFricke
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Setup PowerShell
-      uses: CRFricke/Setup-PowerShell@v1.0.9
+      uses: CRFricke/Setup-PowerShell@v1.0.10
 
     - name: Checkout
       uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
       shell: pwsh
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_PREFIX: 'v8'
+          TAG_PREFIX: 'v9'
       run: |
         Get-VersionVariables
         if ($Tag_PreRelease -or $Tag_Build) { throw "Invalid GITHUB_REF for release." }
@@ -33,7 +33,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
         source-url: https://nuget.pkg.github.com/CRFricke/index.json
         owner: CRFricke
       env:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Setup PowerShell
-      uses: CRFricke/Setup-PowerShell@v1.0.9
+      uses: CRFricke/Setup-PowerShell@v1.0.10
 
     - name: Checkout
       uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
       shell: pwsh
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_PREFIX: 'v8'
+          TAG_PREFIX: 'v9'
       run: |
         Get-VersionVariables
         Set-ActionVariable "BUILD_VERSION" "$Tag_Version"
@@ -32,7 +32,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
         source-url: https://nuget.pkg.github.com/CRFricke/index.json
         owner: CRFricke
       env:


### PR DESCRIPTION
Update workflows for .NET 9 and PowerShell v1.0.10

#### PR Classification
Workflow and build system update to support .NET 9 and new versioning.

#### PR Summary
This pull request updates GitHub Actions workflows to target .NET 9 and aligns versioning and tooling accordingly.
- dotnet.yml, release.yml, tag.yml: Updated CRFricke/Setup-PowerShell to v1.0.10.
- dotnet.yml, release.yml, tag.yml: Changed TAG_PREFIX from 'v8' to 'v9'.
- dotnet.yml, release.yml, tag.yml: Updated .NET SDK version from 8.0.x to 9.0.x.
