### PR TITLE
Update to .NET 10, modernize test infra, and refactor tests

### DIFF
--- a/EF.Core.Utilities.Test.Web/Data/ApplicationDbContext.cs
+++ b/EF.Core.Utilities.Test.Web/Data/ApplicationDbContext.cs
@@ -10,8 +10,16 @@ namespace EF.Core.Utilities.Test.Web.Data
 {
     public class ApplicationDbContext : DbContext, ISeedingContext
     {
+        /// <summary>
+        /// Used for integration testing with an in-memory database provider. 
+        /// Do not use this constructor in production code.
+        /// </summary>
+        public ApplicationDbContext()
+        { }
+
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
         { }
+
 
         protected override void OnModelCreating(ModelBuilder builder)
         {

--- a/EF.Core.Utilities.Test.Web/EF.Core.Utilities.Test.Web.csproj
+++ b/EF.Core.Utilities.Test.Web/EF.Core.Utilities.Test.Web.csproj
@@ -7,20 +7,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.4">
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\EF.Core.Utilities.Test\EF.Core.Utilities.Test.csproj" />
     <ProjectReference Include="..\EF.Core.Utilities\EF.Core.Utilities.csproj" />
   </ItemGroup>
 

--- a/EF.Core.Utilities.Test.Web/Properties/launchSettings.json
+++ b/EF.Core.Utilities.Test.Web/Properties/launchSettings.json
@@ -12,8 +12,7 @@
       "commandName": "IISExpress",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     "EF.Core.Utilities.Test.Web": {
@@ -21,8 +20,7 @@
       "launchBrowser": true,
       "applicationUrl": "https://EfCoreUtilities.dev.localhost:5001;http://EfCoreUtilities.dev.localhost:5000",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/EF.Core.Utilities.Test/DbInitializerTests.cs
+++ b/EF.Core.Utilities.Test/DbInitializerTests.cs
@@ -7,14 +7,18 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
 using Moq;
-using System;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace EF.Core.Utilities.Test;
 
-public class DbInitializerTests
+public class DbInitializerTests : IClassFixture<WebAppFactory>
 {
+    private readonly WebAppFactory _webAppFactory;
+
+    public DbInitializerTests(WebAppFactory webAppFactory)
+    {
+        _webAppFactory = webAppFactory;
+    }
+
     [Fact(DisplayName = "Issues LogWarning when DbInitializerOptions is empty")]
     public async Task Test01Async()
     {
@@ -22,10 +26,10 @@ public class DbInitializerTests
             [], 
             out Mock<DbContext> dbContext, out Mock<IMigrator> migrator, out Mock<DatabaseFacade> dbFacade, out FakeLogger<DbInitializer> logger);
 
-        await dbInitializer.StartAsync(default);
+        await dbInitializer.StartAsync(TestContext.Current.CancellationToken);
 
-        migrator.Verify(m => m.MigrateAsync(null, default), Times.Never());
-        dbFacade.Verify(db => db.EnsureCreatedAsync(default), Times.Never());
+        migrator.Verify(m => m.MigrateAsync(null, It.IsAny<CancellationToken>()), Times.Never());
+        dbFacade.Verify(db => db.EnsureCreatedAsync(It.IsAny<CancellationToken>()), Times.Never());
         dbContext.As<ISeedingContext>().Verify(sc => sc.SeedDatabaseAsync(It.IsAny<IServiceProvider>()), Times.Never());
 
         Assert.Equal(1, logger.Collector.Count);
@@ -41,10 +45,10 @@ public class DbInitializerTests
             new DbInitializerOptions().UseDbContext<DbContext>(dbInitializationOption),
             out Mock<DbContext> dbContext, out Mock<IMigrator> migrator, out Mock<DatabaseFacade> dbFacade, out FakeLogger<DbInitializer> logger);
 
-        await dbInitializer.StartAsync(default);
+        await dbInitializer.StartAsync(TestContext.Current.CancellationToken);
 
-        migrator.Verify(m => m.MigrateAsync(null, default), Times.Never());
-        dbFacade.Verify(db => db.EnsureCreatedAsync(default), Times.Never());
+        migrator.Verify(m => m.MigrateAsync(null, It.IsAny<CancellationToken>()), Times.Never());
+        dbFacade.Verify(db => db.EnsureCreatedAsync(It.IsAny<CancellationToken>()), Times.Never());
         dbContext.As<ISeedingContext>().Verify(sc => sc.SeedDatabaseAsync(It.IsAny<IServiceProvider>()), Times.Never());
 
         Assert.Equal(1, logger.Collector.Count);
@@ -60,10 +64,10 @@ public class DbInitializerTests
             new DbInitializerOptions().UseDbContext<DbContext>(dbInitializationOption),
             out Mock<DbContext> dbContext, out Mock<IMigrator> migrator, out Mock<DatabaseFacade> dbFacade, out FakeLogger<DbInitializer> logger);
 
-        await dbInitializer.StartAsync(default);
+        await dbInitializer.StartAsync(TestContext.Current.CancellationToken);
 
-        migrator.Verify(m => m.MigrateAsync(null, default), Times.Once());
-        dbFacade.Verify(db => db.EnsureCreatedAsync(default), Times.Never());
+        migrator.Verify(m => m.MigrateAsync(null, It.IsAny<CancellationToken>()), Times.Once());
+        dbFacade.Verify(db => db.EnsureCreatedAsync(It.IsAny<CancellationToken>()), Times.Never());
         dbContext.As<ISeedingContext>().Verify(sc => sc.SeedDatabaseAsync(It.IsAny<IServiceProvider>()), Times.Once());
 
         Assert.Equal(1, logger.Collector.Count);
@@ -79,10 +83,10 @@ public class DbInitializerTests
             new DbInitializerOptions().UseDbContext<DbContext>(dbInitializationOption),
             out Mock<DbContext> dbContext, out Mock<IMigrator> migrator, out Mock<DatabaseFacade> dbFacade, out FakeLogger<DbInitializer> logger);
 
-        await dbInitializer.StartAsync(default);
+        await dbInitializer.StartAsync(TestContext.Current.CancellationToken);
 
-        migrator.Verify(m => m.MigrateAsync(null, default), Times.Never());
-        dbFacade.Verify(db => db.EnsureCreatedAsync(default), Times.Once());
+        migrator.Verify(m => m.MigrateAsync(null, It.IsAny<CancellationToken>()), Times.Never());
+        dbFacade.Verify(db => db.EnsureCreatedAsync(It.IsAny<CancellationToken>()), Times.Once());
         dbContext.As<ISeedingContext>().Verify(sc => sc.SeedDatabaseAsync(It.IsAny<IServiceProvider>()), Times.Once());
 
         Assert.Equal(1, logger.Collector.Count);
@@ -98,10 +102,10 @@ public class DbInitializerTests
             new DbInitializerOptions().UseDbContext<DbContext>(dbInitializationOption),
             out Mock<DbContext> dbContext, out Mock<IMigrator> migrator, out Mock<DatabaseFacade> dbFacade, out FakeLogger<DbInitializer> logger);
 
-        await dbInitializer.StartAsync(default);
+        await dbInitializer.StartAsync(TestContext.Current.CancellationToken);
 
-        migrator.Verify(m => m.MigrateAsync(null, default), Times.Never());
-        dbFacade.Verify(db => db.EnsureCreatedAsync(default), Times.Never());
+        migrator.Verify(m => m.MigrateAsync(null, It.IsAny<CancellationToken>()), Times.Never());
+        dbFacade.Verify(db => db.EnsureCreatedAsync(It.IsAny<CancellationToken>()), Times.Never());
         dbContext.As<ISeedingContext>().Verify(sc => sc.SeedDatabaseAsync(It.IsAny<IServiceProvider>()), Times.Once());
 
         Assert.Equal(1, logger.Collector.Count);
@@ -119,10 +123,10 @@ public class DbInitializerTests
                 .UseDbContext<DbContext>(DbInitializationOption.Migrate),
             out Mock<DbContext> dbContext, out Mock<IMigrator> migrator, out Mock<DatabaseFacade> dbFacade, out FakeLogger<DbInitializer> logger);
 
-        await dbInitializer.StartAsync(default);
+        await dbInitializer.StartAsync(TestContext.Current.CancellationToken);
 
-        migrator.Verify(m => m.MigrateAsync(null, default), Times.Never());
-        dbFacade.Verify(db => db.EnsureCreatedAsync(default), Times.Never());
+        migrator.Verify(m => m.MigrateAsync(null, It.IsAny<CancellationToken>()), Times.Never());
+        dbFacade.Verify(db => db.EnsureCreatedAsync(It.IsAny<CancellationToken>()), Times.Never());
         dbContext.As<ISeedingContext>().Verify(sc => sc.SeedDatabaseAsync(It.IsAny<IServiceProvider>()), Times.Once());
 
         Assert.Equal(2, logger.Collector.Count);
@@ -142,10 +146,10 @@ public class DbInitializerTests
             dbException: expectedException
             );
 
-        await dbInitializer.StartAsync(default);
+        await dbInitializer.StartAsync(TestContext.Current.CancellationToken);
 
-        migrator.Verify(m => m.MigrateAsync(null, default), Times.Once());
-        dbFacade.Verify(db => db.EnsureCreatedAsync(default), Times.Never());
+        migrator.Verify(m => m.MigrateAsync(null, It.IsAny<CancellationToken>()), Times.Once());
+        dbFacade.Verify(db => db.EnsureCreatedAsync(It.IsAny<CancellationToken>()), Times.Never());
         dbContext.As<ISeedingContext>().Verify(sc => sc.SeedDatabaseAsync(It.IsAny<IServiceProvider>()), Times.Never());
 
         Assert.Equal(1, logger.Collector.Count);
@@ -167,10 +171,10 @@ public class DbInitializerTests
             dbException: expectedException
             );
 
-        await dbInitializer.StartAsync(default);
+        await dbInitializer.StartAsync(TestContext.Current.CancellationToken);
 
-        migrator.Verify(m => m.MigrateAsync(null, default), Times.Never());
-        dbFacade.Verify(db => db.EnsureCreatedAsync(default), Times.Once());
+        migrator.Verify(m => m.MigrateAsync(null, It.IsAny<CancellationToken>()), Times.Never());
+        dbFacade.Verify(db => db.EnsureCreatedAsync(It.IsAny<CancellationToken>()), Times.Once());
         dbContext.As<ISeedingContext>().Verify(sc => sc.SeedDatabaseAsync(It.IsAny<IServiceProvider>()), Times.Never());
 
         Assert.Equal(1, logger.Collector.Count);
@@ -192,10 +196,10 @@ public class DbInitializerTests
             seedException: expectedException
             );
 
-        await dbInitializer.StartAsync(default);
+        await dbInitializer.StartAsync(TestContext.Current.CancellationToken);
 
-        migrator.Verify(m => m.MigrateAsync(null, default), Times.Never());
-        dbFacade.Verify(db => db.EnsureCreatedAsync(default), Times.Once());
+        migrator.Verify(m => m.MigrateAsync(null, It.IsAny<CancellationToken>()), Times.Never());
+        dbFacade.Verify(db => db.EnsureCreatedAsync(It.IsAny<CancellationToken>()), Times.Once());
         dbContext.As<ISeedingContext>().Verify(sc => sc.SeedDatabaseAsync(It.IsAny<IServiceProvider>()), Times.Once());
 
         Assert.Equal(1, logger.Collector.Count);
@@ -217,18 +221,18 @@ public class DbInitializerTests
     /// <returns>The new DbInitializer instance.</returns>
     private static DbInitializer SetupTestEnvironment(DbInitializerOptions options,  
         out Mock<DbContext> dbContextMock, out Mock<IMigrator> migratorMock, out Mock<DatabaseFacade> dbFacadeMock, out FakeLogger<DbInitializer> fakeLogger,
-        Exception dbException = null, Exception seedException = null
+        Exception dbException = null!, Exception seedException = null!
         )
     {
         var logger = new FakeLogger<DbInitializer>();
 
         var migrator = new Mock<IMigrator>();
         if (dbException == null) {
-            migrator.Setup(m => m.MigrateAsync(null, default)).Returns(Task.CompletedTask);
+            migrator.Setup(m => m.MigrateAsync(null, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
         } 
         else {
-            migrator.Setup(m => m.MigrateAsync(null, default)).Throws(dbException);
-        } 
+            migrator.Setup(m => m.MigrateAsync(null, It.IsAny<CancellationToken>())).Throws(dbException);
+        }
 
         var dbContext = new Mock<DbContext>();
         dbContext.As<IInfrastructure<IServiceProvider>>().Setup(sp => sp.Instance).Returns(
@@ -244,17 +248,17 @@ public class DbInitializerTests
 
         var dbFacade = new Mock<DatabaseFacade>(dbContext.Object);
         if (dbException == null) {
-            dbFacade.Setup(db => db.EnsureCreatedAsync(default)).Returns(Task.FromResult(true));
+            dbFacade.Setup(db => db.EnsureCreatedAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
         }
         else {
-            dbFacade.Setup(db => db.EnsureCreatedAsync(default)).Throws(dbException);
+            dbFacade.Setup(db => db.EnsureCreatedAsync(It.IsAny<CancellationToken>())).Throws(dbException);
         }
 
         dbContext.Setup(c => c.Database).Returns(dbFacade.Object);
 
         var scopedProvider = Mock.Of<IServiceProvider>(
             sp => sp.GetService(typeof(ILoggerFactory)) ==
-                Mock.Of<ILoggerFactory>(lf => lf.CreateLogger(typeof(DbInitializer).FullName) == logger) &&
+                Mock.Of<ILoggerFactory>(lf => lf.CreateLogger(typeof(DbInitializer).FullName!) == logger) &&
             sp.GetService(typeof(IOptions<DbInitializerOptions>)) ==
                 Mock.Of<IOptions<DbInitializerOptions>>(o => o.Value == options) &&
             sp.GetService(typeof(DbContext)) == dbContext.Object

--- a/EF.Core.Utilities.Test/EF.Core.Utilities.Test.csproj
+++ b/EF.Core.Utilities.Test/EF.Core.Utilities.Test.csproj
@@ -2,30 +2,30 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CRFricke.Test.Support" Version="10.0.0-beta1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <Using Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\EF.Core.Utilities\EF.Core.Utilities.csproj" />
+	<PackageReference Include="coverlet.MTP" Version="10.0.0" />
+	<PackageReference Include="CRFricke.Test.Support" Version="10.0.0-beta3.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0" />
+	<PackageReference Include="Microsoft.Testing.Platform" Version="2.2.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EF.Core.Utilities.Test.Web\EF.Core.Utilities.Test.Web.csproj" />
   </ItemGroup>
 
 </Project>

--- a/EF.Core.Utilities.Test/WebAppFactory.cs
+++ b/EF.Core.Utilities.Test/WebAppFactory.cs
@@ -1,0 +1,13 @@
+﻿using CRFricke.Test.Support.Infrastructure;
+using EF.Core.Utilities.Test.Web.Areas.Identity;
+using EF.Core.Utilities.Test.Web.Data;
+using Microsoft.Extensions.Hosting;
+
+namespace EF.Core.Utilities.Test;
+
+public class WebAppFactory : WebApplicationFactory<IdentityHostingStartup, ApplicationDbContext>
+{
+    public override string HostingEnvironment => Environments.Development;
+
+    public override string HostUrl => "http://EfCoreUtilities.dev.localhost";
+}

--- a/EF.Core.Utilities.slnx
+++ b/EF.Core.Utilities.slnx
@@ -1,4 +1,14 @@
 <Solution>
+  <Folder Name="/Solution Items/">
+    <File Path="global.json" />
+    <File Path="nuget.config" />
+  </Folder>
+  <Folder Name="/Solution Items/.github/" />
+  <Folder Name="/Solution Items/.github/workflows/">
+    <File Path=".github/workflows/dotnet.yml" />
+    <File Path=".github/workflows/release.yml" />
+    <File Path=".github/workflows/tag.yml" />
+  </Folder>
   <Project Path="EF.Core.Utilities.Test.Web/EF.Core.Utilities.Test.Web.csproj" />
   <Project Path="EF.Core.Utilities.Test/EF.Core.Utilities.Test.csproj" />
   <Project Path="EF.Core.Utilities/EF.Core.Utilities.csproj" />

--- a/EF.Core.Utilities/EF.Core.Utilities.csproj
+++ b/EF.Core.Utilities/EF.Core.Utilities.csproj
@@ -55,9 +55,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.12" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.12" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+	<clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="github" value="https://nuget.pkg.github.com/CRFricke/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="github">
+      <package pattern="CRFricke.*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
- Upgrade Microsoft.AspNetCore and EF Core packages to 10.0.7
- Switch test project to Microsoft Testing Platform (MTP)
- Enable implicit usings and nullable reference types in tests
- Add WebAppFactory for integration testing
- Add parameterless ctor to ApplicationDbContext for testing
- Refactor DbInitializerTests for better async and Moq usage
- Update solution and NuGet config for new test runner and sources
- General code cleanup and improved maintainability